### PR TITLE
Update docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ In this repository, you'll find numerous core components of the OP Stack, the de
 
 ## Documentation
 
-- If you want to build on top of OP Mainnet, refer to the [Optimism Community Hub](https://community.optimism.io)
-- If you want to build your own OP Stack based blockchain, refer to the [OP Stack docs](https://stack.optimism.io)
+- If you want to build on top of OP Mainnet, refer to the [Optimism Documentation](https://docs.optimism.io)
+- If you want to build your own OP Stack based blockchain, refer to the [OP Stack docs](https://docs.optimism.io/stack/getting-started)
 - If you want to contribute to the OP Stack, check out the [Protocol Specs](./specs)
 
 ## Community


### PR DESCRIPTION
- point from community docs to docs.optimism.io
- point from stack docs to docs.optimism.io

